### PR TITLE
Remove VulkanMod Compat Error.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,8 +39,7 @@
     "slight-gui-modifications": "*"
   },
   "breaks": {
-    "optifabric": "*",
-    "vulkanmod": "*"
+    "optifabric": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
With all the recent changes to VulkanMod, we now have support for ImmediatelyFast which seems to work as expected.