### PR TITLE
Fix conflict with Show Me Your Skin armor trim rendering modifications

### DIFF
--- a/src/main/java/net/raphimc/immediatelyfast/injection/ImmediatelyFastMixinPlugin.java
+++ b/src/main/java/net/raphimc/immediatelyfast/injection/ImmediatelyFastMixinPlugin.java
@@ -83,6 +83,13 @@ public class ImmediatelyFastMixinPlugin implements IMixinConfigPlugin {
             return false;
         }
 
+        if (!ImmediatelyFast.config.debug_only_and_not_recommended_disable_mod_conflict_handling) {
+            if (mixinName.equals("core.MixinArmorFeatureRenderer") && FabricLoader.getInstance().isModLoaded("showmeyourskin")) {
+                ImmediatelyFast.LOGGER.warn("Show Me Your Skin detected. Disabling separate armor trim pass optimization.");
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
This PR currently contains a partial fix for a compatibility issue with my mod, [Show Me Your Skin](https://github.com/enjarai/show-me-your-skin). The main issue occurs when my mod is used to modify the transparency of trimmed armor. ImmediatelyFast modifies the order in which trims are rendered in relation to the armor itself, which breaks some assumptions my mixins make, resulting in all trims being rendered with the same transparency as the trim on the players helmet. See below image and https://github.com/enjarai/show-me-your-skin/issues/50:

![image](https://github.com/RaphiMC/ImmediatelyFast/assets/38552516/e0662d97-02f9-40da-a307-8d1fb897e70e)

I've attempted to address this issue using a compatibility mixin, but that has not proven to be feasible. As such, I'm creating this PR to disable the optimisation in question when my mod is loaded. 

While this does fix the issue at hand, another problem popped up during my testing that I don't know how to solve. It seems like the overlapping transparency of trims on armor isn't handled properly by the renderer when ImmediatelyFast is present, see the following images:

With only Show Me Your Skin:
![image](https://github.com/RaphiMC/ImmediatelyFast/assets/38552516/33f2279e-0eaa-485d-9c4c-9bbd8a125635)

With Show Me Your Skin and my patched version of ImmediatelyFast:
![image](https://github.com/RaphiMC/ImmediatelyFast/assets/38552516/cb562818-787e-4142-a860-96c26c931b30)

Note that the trims render on all pieces when only SMYS is loaded, but seem to render below the armor itself when using IF.

Because of this, I've made this a draft PR, and hope to discuss a potential solution to completely fix compatibility. It should be noted that my knowledge about Minecraft rendering is rather limited, so its not unlikely that this is something that I'd have to fix on my side. Please let me know what you think.