### PR TITLE
Lowered fabricloader requirement for compatibility reasons

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
     "immediatelyfast-common.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.14.25",
     "minecraft": "1.19.4",
     "java": ">=17"
   },


### PR DESCRIPTION
Lowered fabricloader requirement for Minecraft 1.19.4 to be able to use Memory Leak Fix and some other mods again that do not support loader version >=0.15.0. Works flawlessly with my 100+ mods pack (tested for serveral hours).