### PR TITLE
Add support for Iris 1.7.0 (beta)

### DIFF
--- a/common/src/main/java/net/raphimc/immediatelyfast/compat/IrisCompat.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/compat/IrisCompat.java
@@ -24,6 +24,7 @@ import net.minecraft.client.render.VertexFormat;
 import net.raphimc.immediatelyfast.ImmediatelyFast;
 
 import java.lang.invoke.*;
+import java.lang.reflect.Field;
 import java.util.function.BooleanSupplier;
 
 public class IrisCompat {
@@ -34,23 +35,35 @@ public class IrisCompat {
     public static BooleanConsumer renderWithExtendedVertexFormat;
     public static TriConsumer<BufferBuilder, VertexFormat.DrawMode, VertexFormat> iris$beginWithoutExtending;
 
+    private static String[] PACKAGE_NAMES = new String[] {
+            "net.coderbot.iris.vertices",
+            "net.irisshaders.iris.vertices"
+    };
+
     public static void init() {
         IRIS_LOADED = true;
-        try {
-            final MethodHandles.Lookup lookup = MethodHandles.lookup();
-            final Class<?> immediateStateClass = Class.forName("net.coderbot.iris.vertices.ImmediateState");
-            final Class<?> extendingBufferBuilderClass = Class.forName("net.coderbot.iris.vertices.ExtendingBufferBuilder");
+        Throwable throwable = null;
+        for (int i = 0; i < PACKAGE_NAMES.length; i++) {
+            String packageName = PACKAGE_NAMES[i];
+            try {
+                final MethodHandles.Lookup lookup = MethodHandles.lookup();
+                final Class<?> immediateStateClass = Class.forName(packageName + ".ImmediateState");
+                final Class<?> extendingBufferBuilderClass = Class.forName(packageName + ".ExtendingBufferBuilder");
 
-            isRenderingLevel = FieldAccessor.makeGetter(BooleanSupplier.class, null, immediateStateClass.getDeclaredField("isRenderingLevel"));
-            renderWithExtendedVertexFormat = FieldAccessor.makeSetter(BooleanConsumer.class, null, immediateStateClass.getDeclaredField("renderWithExtendedVertexFormat"));
+                isRenderingLevel = FieldAccessor.makeGetter(BooleanSupplier.class, null, immediateStateClass.getDeclaredField("isRenderingLevel"));
+                renderWithExtendedVertexFormat = FieldAccessor.makeSetter(BooleanConsumer.class, null, immediateStateClass.getDeclaredField("renderWithExtendedVertexFormat"));
 
-            final MethodHandle iris$beginWithoutExtendingMH = lookup.findVirtual(extendingBufferBuilderClass, "iris$beginWithoutExtending", MethodType.methodType(void.class, VertexFormat.DrawMode.class, VertexFormat.class));
-            final CallSite iris$beginWithoutExtendingCallSite = LambdaMetafactory.metafactory(lookup, "accept", MethodType.methodType(TriConsumer.class), MethodType.methodType(void.class, Object.class, Object.class, Object.class), iris$beginWithoutExtendingMH, iris$beginWithoutExtendingMH.type());
-            iris$beginWithoutExtending = (TriConsumer<BufferBuilder, VertexFormat.DrawMode, VertexFormat>) iris$beginWithoutExtendingCallSite.getTarget().invoke();
-        } catch (Throwable e) {
-            ImmediatelyFast.LOGGER.error("Failed to initialize Iris compatibility. Try updating Iris and ImmediatelyFast before reporting this on GitHub", e);
-            System.exit(-1);
+                final MethodHandle iris$beginWithoutExtendingMH = lookup.findVirtual(extendingBufferBuilderClass, "iris$beginWithoutExtending", MethodType.methodType(void.class, VertexFormat.DrawMode.class, VertexFormat.class));
+                final CallSite iris$beginWithoutExtendingCallSite = LambdaMetafactory.metafactory(lookup, "accept", MethodType.methodType(TriConsumer.class), MethodType.methodType(void.class, Object.class, Object.class, Object.class), iris$beginWithoutExtendingMH, iris$beginWithoutExtendingMH.type());
+                iris$beginWithoutExtending = (TriConsumer<BufferBuilder, VertexFormat.DrawMode, VertexFormat>) iris$beginWithoutExtendingCallSite.getTarget().invoke();
+                return;
+            } catch (Throwable t) {
+                throwable = t;
+            }
         }
+
+        ImmediatelyFast.LOGGER.error("Failed to initialize Iris compatibility. Try updating Iris and ImmediatelyFast before reporting this on GitHub", throwable);
+        System.exit(-1);
     }
 
 }


### PR DESCRIPTION
Simply checks the alternate package `net.irisshaders` if net.coderbot does not exist.