### PR TITLE
Render armor trims after armor

### DIFF
--- a/common/src/main/java/net/raphimc/immediatelyfast/feature/core/BatchableBufferSource.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/feature/core/BatchableBufferSource.java
@@ -208,6 +208,8 @@ public class BatchableBufferSource extends VertexConsumerProvider.Immediate impl
                         return 1;
                     }
                 } else if (textureId.equals(TexturedRenderLayers.ARMOR_TRIMS_ATLAS_TEXTURE)) {
+                    return 2;
+                } else if (layer.name.startsWith("armor")) {
                     return 1;
                 } else if (layer.name.startsWith("text") || layer.name.startsWith("neoforge_text")) {
                     // Draws vanilla text over custom font layers


### PR DESCRIPTION
This PR extends the RenderLayer ordering logic of BatchableBufferSource, such that armor pieces are always rendered before armor trims. It was done to fix a bug that was reported [here](https://github.com/Exopandora/ShoulderSurfing/issues/323). Shoulder Surfing Reloaded (the mod where the bug was originally reported to), has the feature to turn the player model transparent when the third person camera gets too close to it. In order to achieve that, the render type "armorCutoutNoCull" gets mapped to "armorTranslucent", using [a mixin](https://github.com/Exopandora/ShoulderSurfing/blob/master/common/src/main/java/com/github/exopandora/shouldersurfing/mixins/MixinRenderType.java). Now, in combination with ImmediatelyFast, this causes the armor trims to be rendered before the armor itself, hiding the trims. More specifically, the render type for the armor trims gets mapped to priority 1, because of the texture used, and the armor render type (now "armorTranslucent") gets mapped to Integer.MAX_VALUE - 1, because it supports transparency. Performance should be slightly worse, as the proposed change will revert some optimization, but I think the impact will we negligible. The only other way of fixing this (at least that I'm aware of), would be to apply the same changes that are in this PR via mixins, but I would rather try with this PR first.

Note: The bug is not present when Iris is installed. Afaik, Iris does some special transparency sorting, so that might be the reason.