### PR TITLE
Downgrade fabric loader minimum supported version

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
   ],
   "accessWidener": "immediatelyfast.accesswidener",
   "depends": {
-    "fabricloader": ">=0.18.5",
+    "fabricloader": ">=0.16.14",
     "minecraft": "26.1",
     "java": ">=25"
   },


### PR DESCRIPTION
The fabric loader version specified in fabric.mod.json needs to be the *minimum* supported version, which for 26.1 is 0.16.14