### PR TITLE
Bump minecraft version dependency to work with 26.1.2

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "accessWidener": "immediatelyfast.accesswidener",
   "depends": {
     "fabricloader": ">=0.18.5",
-    "minecraft": ">=26.1 <=26.1.1",
+    "minecraft": ">=26.1 <=26.1.2",
     "java": ">=25"
   },
   "recommends": {

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -28,6 +28,6 @@ side = "CLIENT"
 [[dependencies.immediatelyfast]]
 modId = "minecraft"
 required = true
-versionRange = "[26.1,26.1.1]"
+versionRange = "[26.1,26.1.2]"
 ordering = "NONE"
 side = "CLIENT"


### PR DESCRIPTION
Minecraft 26.1.2 is just a hotfix, no changes are needed, just bumping the version range and it launches. Mainly doing this for myself, but putting it here to save you some work if you want.
I tested the fabric version, I couldn't test neoforge, since it's not out yet for 26.1.2, but it should work just fine.