### PR TITLE
don't generate large map atlasses with core shader conflicts

### DIFF
--- a/common/src/main/java/net/raphimc/immediatelyfast/feature/core/ImmediatelyFastRuntimeConfig.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/feature/core/ImmediatelyFastRuntimeConfig.java
@@ -21,6 +21,7 @@ public class ImmediatelyFastRuntimeConfig {
 
     public boolean font_atlas_resizing;
     public boolean disable_fast_buffer_upload;
+    public boolean map_atlas_generation;
 
     public ImmediatelyFastRuntimeConfig(final ImmediatelyFastConfig config) {
         this.font_atlas_resizing = config.font_atlas_resizing;
@@ -31,6 +32,7 @@ public class ImmediatelyFastRuntimeConfig {
         return switch (key) {
             case "font_atlas_resizing" -> this.font_atlas_resizing;
             case "disable_fast_buffer_upload" -> this.disable_fast_buffer_upload;
+            case "map_atlas_generation" -> this.map_atlas_generation;
             default -> defaultValue;
         };
     }

--- a/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/map_atlas_generation/MixinMapTextureManager.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/map_atlas_generation/MixinMapTextureManager.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.client.resources.MapTextureManager;
 import net.minecraft.world.level.saveddata.maps.MapId;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import net.raphimc.immediatelyfast.ImmediatelyFast;
 import net.raphimc.immediatelyfast.feature.map_atlas_generation.MapAtlas;
 import net.raphimc.immediatelyfast.injection.interfaces.IMapTextureManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -55,18 +56,20 @@ public abstract class MixinMapTextureManager implements IMapTextureManager {
 
     @Inject(method = "getOrCreateMapInstance", at = @At("HEAD"))
     private void ensureHasAtlasLocation(final MapId id, final MapItemSavedData data, final CallbackInfoReturnable<?> cir) {
-        this.immediatelyFast$mapIdToAtlasLocation.computeIfAbsent(id.id(), _ -> {
-            for (MapAtlas atlas : this.immediatelyFast$atlases.values()) {
-                final int location = atlas.getNextLocation();
-                if (location != -1) {
-                    return location;
+        if (ImmediatelyFast.runtimeConfig.map_atlas_generation) {
+            this.immediatelyFast$mapIdToAtlasLocation.computeIfAbsent(id.id(), _ -> {
+                for (MapAtlas atlas : this.immediatelyFast$atlases.values()) {
+                    final int location = atlas.getNextLocation();
+                    if (location != -1) {
+                        return location;
+                    }
                 }
-            }
 
-            final MapAtlas atlas = new MapAtlas(this.immediatelyFast$atlases.size());
-            this.immediatelyFast$atlases.put(atlas.getId(), atlas);
-            return atlas.getNextLocation();
-        });
+                final MapAtlas atlas = new MapAtlas(this.immediatelyFast$atlases.size());
+                this.immediatelyFast$atlases.put(atlas.getId(), atlas);
+                return atlas.getNextLocation();
+            });
+        }
     }
 
     @Override

--- a/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/map_atlas_generation/MixinMapTextureManager_MapInstance.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/map_atlas_generation/MixinMapTextureManager_MapInstance.java
@@ -51,6 +51,9 @@ public abstract class MixinMapTextureManager_MapInstance {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void getAtlasParameters(final MapTextureManager mapTextureManager, final int id, final MapItemSavedData data, final CallbackInfo ci) {
+        if (!ImmediatelyFast.runtimeConfig.map_atlas_generation) {
+            return;
+        }
         final int location = ((IMapTextureManager) mapTextureManager).immediatelyFast$getAtlasLocation(id);
         if (location != -1) {
             this.immediatelyFast$atlasTexture = ((IMapTextureManager) mapTextureManager).immediatelyFast$getAtlas(MapAtlas.getAtlasIdFromLocation(location)).getTexture();
@@ -63,7 +66,7 @@ public abstract class MixinMapTextureManager_MapInstance {
 
     @Inject(method = "updateTextureIfNeeded", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/texture/DynamicTexture;upload()V", shift = At.Shift.AFTER))
     private void updateAtlasTexture(final CallbackInfo ci) {
-        if (this.immediatelyFast$atlasTexture != null) {
+        if (this.immediatelyFast$atlasTexture != null && ImmediatelyFast.runtimeConfig.map_atlas_generation) {
             RenderSystem.getDevice().createCommandEncoder().writeToTexture(this.immediatelyFast$atlasTexture.getTexture(), this.texture.getPixels(), 0, 0, this.immediatelyFast$atlasX, this.immediatelyFast$atlasY);
         }
     }

--- a/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/resource_pack_conflict_handling/MixinShaderManager.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/resource_pack_conflict_handling/MixinShaderManager.java
@@ -36,6 +36,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Mixin(ShaderManager.class)
@@ -43,7 +44,7 @@ public abstract class MixinShaderManager {
 
     @Inject(method = "apply(Lnet/minecraft/client/renderer/ShaderManager$Configs;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At("RETURN"))
     private void checkForCoreShaderModifications(final ShaderManager.Configs preparations, final ResourceManager manager, final ProfilerFiller profiler, final CallbackInfo ci) {
-        PackResources resourcePackWhichBreaksFontAtlasResizing = null;
+        PackResources resourcePackWhichBreaksFontAtlasResizingAndMapAtlasGeneration = null;
         try {
             final Set<PackResources> breakingResourcePacks = new HashSet<>();
             for (Identifier shaderIdentifier : CoreShaderBlacklist.getBlacklist()) {
@@ -63,8 +64,9 @@ public abstract class MixinShaderManager {
                 if (metadata == null) {
                     metadata = ImmediatelyFastResourcePackMetadata.DEFAULT;
                 }
-                if (!metadata.compatibleFeatures().contains("font_atlas_resizing")) {
-                    resourcePackWhichBreaksFontAtlasResizing = resourcePack;
+                List<String> compatibleFeatures = metadata.compatibleFeatures();
+                if (!compatibleFeatures.contains("font_atlas_resizing") || !compatibleFeatures.contains("map_atlas_generation")) {
+                    resourcePackWhichBreaksFontAtlasResizingAndMapAtlasGeneration = resourcePack;
                 }
             }
         } catch (IOException e) {
@@ -72,16 +74,22 @@ public abstract class MixinShaderManager {
         }
 
         if (ImmediatelyFast.config.font_atlas_resizing) {
-            if (resourcePackWhichBreaksFontAtlasResizing != null) {
-                ImmediatelyFast.LOGGER.warn("Resource pack " + resourcePackWhichBreaksFontAtlasResizing.packId() + " is not compatible with font atlas resizing. Temporarily disabling font atlas resizing.");
+            if (resourcePackWhichBreaksFontAtlasResizingAndMapAtlasGeneration != null) {
+                ImmediatelyFast.LOGGER.warn("Resource pack " + resourcePackWhichBreaksFontAtlasResizingAndMapAtlasGeneration.packId() + " is not compatible with font atlas resizing and map atlas generation. Temporarily disabling both.");
                 if (ImmediatelyFast.runtimeConfig.font_atlas_resizing) {
                     ImmediatelyFast.runtimeConfig.font_atlas_resizing = false;
                     this.immediatelyFast$reloadFontStorages();
                 }
+                if (ImmediatelyFast.runtimeConfig.map_atlas_generation) {
+                    ImmediatelyFast.runtimeConfig.map_atlas_generation = false;
+                    this.immediatelyFast$reloadMapAtlas();
+                }
             } else if (!ImmediatelyFast.runtimeConfig.font_atlas_resizing) {
-                ImmediatelyFast.LOGGER.info("Re-enabling font atlas resizing because no incompatible resource packs are loaded.");
+                ImmediatelyFast.LOGGER.info("Re-enabling font atlas resizing and map atlas generation because no incompatible resource packs are loaded.");
                 ImmediatelyFast.runtimeConfig.font_atlas_resizing = true;
+                ImmediatelyFast.runtimeConfig.map_atlas_generation = true;
                 this.immediatelyFast$reloadFontStorages();
+                this.immediatelyFast$reloadMapAtlas();
             }
         }
     }
@@ -90,6 +98,12 @@ public abstract class MixinShaderManager {
     private void immediatelyFast$reloadFontStorages() {
         // Force reload the font manager to rebuild the font atlas textures
         Minecraft.getInstance().fontManager.updateOptions(Minecraft.getInstance().options);
+    }
+
+    @Unique
+    private void immediatelyFast$reloadMapAtlas() {
+        // Force the map atlast thing
+        Minecraft.getInstance().getMapTextureManager().resetData();
     }
 
 }


### PR DESCRIPTION
simple patch that skips generating the large atlas if it detects an overwritten core shader in the pack (i did not touch that existing code) and instead goes back to vanilla behaviour. Attached picture show the sampler outputs with the pack and off (sorry for the lack of renderdoc pics, it is very wonky on macOS)
<img width="3680" height="1110" alt="immediatelyfastfix" src="https://github.com/user-attachments/assets/d3d00896-6f11-4154-ac4e-ce7e4b39ba55" />
