### PR TITLE
fix: close config file reader and fix runtime config key lookup

### DIFF
--- a/common/src/main/java/net/raphimc/immediatelyfast/ImmediatelyFast.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/ImmediatelyFast.java
@@ -74,15 +74,13 @@ public class ImmediatelyFast {
         LOGGER.info("Initializing ImmediatelyFast " + VERSION + " on " + gpuModel + " (" + gpuVendor + ") with " + backendName + " " + backendVersion);
 
         final String gpuVendorLower = gpuVendor.toLowerCase();
-        final boolean isNvidia = gpuVendorLower.startsWith("nvidia");
-        final boolean isAmd = gpuVendorLower.startsWith("ati") || gpuVendorLower.startsWith("amd");
         final boolean isIntel = gpuVendorLower.startsWith("intel");
         final boolean isApple = gpuVendorLower.startsWith("apple");
 
         Objects.requireNonNull(ImmediatelyFast.config, "Config not loaded yet");
         Objects.requireNonNull(ImmediatelyFast.runtimeConfig, "Runtime config not created yet");
 
-        ImmediatelyFast.runtimeConfig.fix_slow_buffer_upload_on_apple_gpu &= isApple && backendName.equals("OpenGL") && !(deviceInfo.underlyingExtensions().contains("GL_ARB_direct_state_access") || RenderSystem.getDevice().getDeviceInfo().underlyingExtensions().contains("GL_ARB_buffer_storage"));
+        ImmediatelyFast.runtimeConfig.fix_slow_buffer_upload_on_apple_gpu &= isApple && backendName.equals("OpenGL") && !(deviceInfo.underlyingExtensions().contains("GL_ARB_direct_state_access") || deviceInfo.underlyingExtensions().contains("GL_ARB_buffer_storage"));
         if (ImmediatelyFast.runtimeConfig.avoid_redundant_framebuffer_switching && !ImmediatelyFast.config.debug_only_and_not_recommended_disable_hardware_conflict_handling && isIntel && backendName.equals("OpenGL") && (gpuModel.contains("UHD Graphics") || gpuModel.contains("Xe Graphics"))) {
             LOGGER.warn("Intel UHD Graphics or Intel Xe Graphics detected. Force disabling redundant framebuffer switching optimization.");
             ImmediatelyFast.runtimeConfig.avoid_redundant_framebuffer_switching = false;
@@ -107,8 +105,8 @@ public class ImmediatelyFast {
     public static void loadConfig() {
         final File configFile = PlatformService.INSTANCE.getConfigDirectory().resolve("immediatelyfast.json").toFile();
         if (configFile.exists()) {
-            try {
-                ImmediatelyFast.config = new Gson().fromJson(new FileReader(configFile), ImmediatelyFastConfig.class);
+            try (FileReader reader = new FileReader(configFile)) {
+                ImmediatelyFast.config = new Gson().fromJson(reader, ImmediatelyFastConfig.class);
             } catch (Throwable e) {
                 LOGGER.error("Failed to load ImmediatelyFast config. Resetting it.", e);
             }

--- a/common/src/main/java/net/raphimc/immediatelyfast/feature/core/ImmediatelyFastRuntimeConfig.java
+++ b/common/src/main/java/net/raphimc/immediatelyfast/feature/core/ImmediatelyFastRuntimeConfig.java
@@ -36,7 +36,7 @@ public class ImmediatelyFastRuntimeConfig {
             case "font_atlas_resizing" -> this.font_atlas_resizing;
             case "map_atlas_generation" -> this.map_atlas_generation;
             case "disable_fast_buffer_upload", "fix_slow_buffer_upload_on_apple_gpu" -> this.fix_slow_buffer_upload_on_apple_gpu;
-            case "disable_avoid_redundant_framebuffer_switching" -> this.avoid_redundant_framebuffer_switching;
+            case "disable_avoid_redundant_framebuffer_switching", "avoid_redundant_framebuffer_switching" -> this.avoid_redundant_framebuffer_switching;
             default -> defaultValue;
         };
     }


### PR DESCRIPTION
While reviewing core initialization and runtime configuration routines, I noticed an unclosed stream during config loading, an unhandled key in `ImmediatelyFastRuntimeConfig`, and some dead local variables.

### Changes Proposed:
**Fixes & Stability:**
* Added `"avoid_redundant_framebuffer_switching"` to the switch-case in `ImmediatelyFastRuntimeConfig.getBoolean` so querying runtime config using the non-legacy property name resolves correctly.
* Wrapped `new FileReader(configFile)` in a try-with-resources block within `ImmediatelyFast.loadConfig()` to ensure the reader is closed and file descriptors are not leaked.

**Chores:**
* Removed unused `isNvidia` and `isAmd` local variables in `ImmediatelyFast.onRenderSystemInit()`.
* Replaced a redundant `RenderSystem.getDevice().getDeviceInfo()` call with the local `deviceInfo` variable already in scope.